### PR TITLE
fix: Allow WSL2 access to wezterm cli commands.

### DIFF
--- a/lua/wezterm-move/init.lua
+++ b/lua/wezterm-move/init.lua
@@ -9,7 +9,7 @@ end
 
 local function wezterm_exec(cmd)
   local command = vim.deepcopy(cmd)
-  table.insert(command, 1, "wezterm")
+  table.insert(command, 1, "wezterm.exe")
   table.insert(command, 2, "cli")
   return vim.fn.system(command)
 end


### PR DESCRIPTION
I have used this plugin for a while on regular old windows without an issue but I noticed it didn't work tonight when I was using Wezterm (installed on regular Windows) but was using a neovim instance within WSL2 that the commands failed/couldn't access the Wezterm CLI commands without the addition of this.