### PR TITLE
fix: allow WSL2 access to Wezterm CLI

### DIFF
--- a/lua/wezterm-move/init.lua
+++ b/lua/wezterm-move/init.lua
@@ -9,7 +9,11 @@ end
 
 local function wezterm_exec(cmd)
   local command = vim.deepcopy(cmd)
-  table.insert(command, 1, "wezterm")
+  if vim.fn.executable("wezterm.exe") then
+    table.insert(command, 1, "wezterm.exe")
+  else
+    table.insert(command, 1, "wezterm")
+  end
   table.insert(command, 2, "cli")
   return vim.fn.system(command)
 end


### PR DESCRIPTION
A better approach to #3 and a fix for reverting back to #4. There are other ways to check for WSL vs windows native vs linux/mac but this one seems to be the most straightforward and simple? 

Checking vim.loop.os_uname().sysname isn't as straigh forward because on WSL2 it will return `Linux`. Instead of string matching several items, a Boolean guard clause seemed best.